### PR TITLE
Add about page with team and stats sections

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    domains: ["placehold.co"],
+  },
 };
 
 export default nextConfig;

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,135 @@
+import type { Metadata } from "next";
+import Container from "@/components/ui/Container";
+import Hero from "@/components/sections/Hero";
+import Stats, { Stat } from "@/components/sections/Stats";
+import Team, { TeamMember } from "@/components/sections/Team";
+
+export const metadata: Metadata = {
+  title: "About Us | Elevate Digital",
+  description:
+    "Discover the mission, story and talented team behind Elevate Digital.",
+};
+
+const stats: Stat[] = [
+  { label: "Projects Completed", value: 120 },
+  { label: "Years Experience", value: 10 },
+  { label: "Team Members", value: 8 },
+  { label: "Satisfied Clients", value: 95 },
+];
+
+const team: TeamMember[] = [
+  {
+    name: "Alex Johnson",
+    title: "CEO",
+    bio: "Visionary leader focused on delivering digital excellence.",
+    image: "https://placehold.co/200x200",
+    social: { linkedin: "#", twitter: "#" },
+  },
+  {
+    name: "Sara Kim",
+    title: "CTO",
+    bio: "Architecting scalable solutions with cutting-edge tech.",
+    image: "https://placehold.co/200x200",
+    social: { linkedin: "#", github: "#" },
+  },
+  {
+    name: "David Lee",
+    title: "Lead Developer",
+    bio: "Passionate about clean code and great user experiences.",
+    image: "https://placehold.co/200x200",
+    social: { github: "#" },
+  },
+  {
+    name: "Emily Chen",
+    title: "UI/UX Designer",
+    bio: "Designing intuitive interfaces that delight users.",
+    image: "https://placehold.co/200x200",
+    social: { twitter: "#" },
+  },
+  {
+    name: "Michael Brown",
+    title: "Marketing Strategist",
+    bio: "Crafting campaigns that connect brands with audiences.",
+    image: "https://placehold.co/200x200",
+  },
+  {
+    name: "Olivia Davis",
+    title: "Project Manager",
+    bio: "Keeping projects on track and clients happy.",
+    image: "https://placehold.co/200x200",
+    social: { linkedin: "#" },
+  },
+];
+
+export default function AboutPage() {
+  const differentiators = [
+    "Experienced multidisciplinary team",
+    "Client-centric agile approach",
+    "Proven track record of success",
+    "Cutting-edge technologies",
+    "Transparent communication",
+    "Focus on long-term partnerships",
+  ];
+
+  const story = [
+    { year: "2015", text: "Founded with a passion for digital innovation." },
+    { year: "2017", text: "Launched our first enterprise platform." },
+    { year: "2020", text: "Expanded globally and grew our team." },
+    { year: "2023", text: "Recognized as a leading digital agency." },
+  ];
+
+  return (
+    <main>
+      <Hero title="About Elevate Digital" subtitle="Our Mission">
+        We empower businesses to thrive by transforming ideas into impactful
+        digital experiences.
+      </Hero>
+
+      <section className="py-16" id="our-story">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">Our Story</h2>
+          <ol className="mx-auto mt-8 max-w-2xl border-l border-gray-200 dark:border-gray-700 relative">
+            {story.map((event) => (
+              <li key={event.year} className="ml-6 mb-10">
+                <span className="absolute -left-3 mt-1 h-6 w-6 rounded-full bg-blue-600" />
+                <time className="mb-1 text-sm font-semibold leading-none text-gray-600 dark:text-gray-300">
+                  {event.year}
+                </time>
+                <p className="text-gray-700 dark:text-gray-400">{event.text}</p>
+              </li>
+            ))}
+          </ol>
+        </Container>
+      </section>
+
+      <section className="py-16 bg-gray-50 dark:bg-gray-950">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">Why Choose Us</h2>
+          <ul className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+            {differentiators.map((diff) => (
+              <li
+                key={diff}
+                className="rounded-lg border border-gray-200 bg-white p-6 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900"
+              >
+                {diff}
+              </li>
+            ))}
+          </ul>
+        </Container>
+      </section>
+
+      <section className="py-16">
+        <Container>
+          <Stats stats={stats} />
+        </Container>
+      </section>
+
+      <section className="py-16 bg-gray-50 dark:bg-gray-950">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">Meet the Team</h2>
+          <Team members={team} className="mt-8" />
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+export interface HeroProps {
+  title: string;
+  subtitle?: string;
+  children?: ReactNode;
+}
+
+export default function Hero({ title, subtitle, children }: HeroProps) {
+  return (
+    <section className="relative flex min-h-[60vh] items-center justify-center text-center text-white">
+      <div className="absolute inset-0 bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 animate-gradient" />
+      <div className="relative z-10 px-4 py-24">
+        <h1 className="text-4xl font-bold sm:text-6xl">{title}</h1>
+        {subtitle && <p className="mt-4 text-xl sm:text-2xl">{subtitle}</p>}
+        {children && <div className="mx-auto mt-6 max-w-2xl text-base sm:text-lg">{children}</div>}
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+export interface Stat {
+  label: string;
+  value: number;
+}
+
+export interface StatsProps {
+  stats: Stat[];
+  className?: string;
+}
+
+function useInView<T extends HTMLElement>(options?: IntersectionObserverInit) {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setInView(entry.isIntersecting),
+      options
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [options]);
+
+  return { ref, inView };
+}
+
+export default function Stats({ stats, className }: StatsProps) {
+  const { ref, inView } = useInView<HTMLDivElement>({ threshold: 0.3 });
+  const [counts, setCounts] = useState<number[]>(stats.map(() => 0));
+
+  useEffect(() => {
+    if (!inView) return;
+    const durations = stats.map((s) => Math.min(2000, s.value * 20));
+    const starts = performance.now();
+
+    function animate(now: number) {
+      const elapsed = now - starts;
+      setCounts((prev) =>
+        prev.map((_, i) =>
+          Math.min(
+            stats[i].value,
+            Math.floor((elapsed / durations[i]) * stats[i].value)
+          )
+        )
+      );
+      if (elapsed < Math.max(...durations)) requestAnimationFrame(animate);
+    }
+    requestAnimationFrame(animate);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inView]);
+
+  return (
+    <div ref={ref} className={className}>
+      <dl className="grid grid-cols-2 gap-8 md:grid-cols-4">
+        {stats.map((stat, i) => (
+          <div key={stat.label} className="text-center">
+            <dt className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+              {counts[i]}
+            </dt>
+            <dd className="mt-1 text-sm font-medium text-gray-600 dark:text-gray-300">
+              {stat.label}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/src/components/sections/Team.tsx
+++ b/src/components/sections/Team.tsx
@@ -1,0 +1,99 @@
+"use client";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+
+export interface SocialLinks {
+  twitter?: string;
+  linkedin?: string;
+  github?: string;
+}
+
+export interface TeamMember {
+  name: string;
+  title: string;
+  bio: string;
+  image: string;
+  social?: SocialLinks;
+}
+
+export interface TeamProps {
+  members: TeamMember[];
+  className?: string;
+}
+
+function useInView<T extends HTMLElement>(options?: IntersectionObserverInit) {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setInView(entry.isIntersecting),
+      options
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [options]);
+
+  return { ref, inView };
+}
+
+export default function Team({ members, className }: TeamProps) {
+  const { ref, inView } = useInView<HTMLDivElement>({ threshold: 0.2 });
+
+  return (
+    <div
+      ref={ref}
+      className={
+        "grid gap-8 sm:grid-cols-2 md:grid-cols-3 " + (className ?? "")
+      }
+    >
+      {members.map((member, idx) => (
+        <div
+          key={member.name}
+          className={`rounded-lg border border-gray-200 bg-white p-6 text-center shadow-sm transition duration-700 dark:border-gray-800 dark:bg-gray-900 ${
+            inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
+          }`}
+          style={{ transitionDelay: `${idx * 100}ms` }}
+        >
+          <div className="mx-auto h-24 w-24 overflow-hidden rounded-full">
+            <Image
+              src={member.image}
+              alt={member.name}
+              width={96}
+              height={96}
+            />
+          </div>
+          <h3 className="mt-4 text-lg font-semibold">{member.name}</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{member.title}</p>
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">{member.bio}</p>
+          {member.social && (
+            <div className="mt-3 flex justify-center space-x-4" aria-label="Social links">
+              {member.social.twitter && (
+                <a href={member.social.twitter} className="hover:text-blue-600" aria-label="Twitter">
+                  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M8 19c11 0 17-9 17-17v-1a12 12 0 0 0 3-3 11.96 11.96 0 0 1-3.4.9 6 6 0 0 0 2.6-3.3 12 12 0 0 1-3.8 1.4A6 6 0 0 0 6.3 8.7a17 17 0 0 1-12-6A6 6 0 0 0 4 9.5a6 6 0 0 1-2.7-.7v.1a6 6 0 0 0 4.8 5.9 6 6 0 0 1-2.7.1 6 6 0 0 0 5.6 4.2A12 12 0 0 1 0 17.5 17 17 0 0 0 8 19" />
+                  </svg>
+                </a>
+              )}
+              {member.social.linkedin && (
+                <a href={member.social.linkedin} className="hover:text-blue-600" aria-label="LinkedIn">
+                  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-4 0v7h-4v-7a6 6 0 0 1 6-6zM2 9h4v12H2zM4 3a2 2 0 1 1 0 4 2 2 0 0 1 0-4z" />
+                  </svg>
+                </a>
+              )}
+              {member.social.github && (
+                <a href={member.social.github} className="hover:text-blue-600" aria-label="GitHub">
+                  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path fillRule="evenodd" clipRule="evenodd" d="M12 2a10 10 0 0 0-3.162 19.49c.5.09.683-.217.683-.482 0-.237-.009-.868-.013-1.704-2.782.605-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.004.07 1.532 1.032 1.532 1.032.892 1.53 2.341 1.088 2.91.833.091-.647.35-1.088.636-1.338-2.221-.252-4.555-1.11-4.555-4.941 0-1.091.39-1.984 1.029-2.682-.103-.253-.446-1.27.098-2.646 0 0 .84-.269 2.75 1.026A9.563 9.563 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.295 2.748-1.026 2.748-1.026.546 1.376.203 2.393.1 2.646.64.698 1.028 1.591 1.028 2.682 0 3.841-2.337 4.687-4.566 4.935.36.31.68.92.68 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.576.688.479A10 10 0 0 0 12 2Z" />
+                  </svg>
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add remote image configuration
- create reusable Hero, Stats, and Team components with intersection observer animations
- implement new `/about` page with company story, differentiators, stats, and team showcase

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862c9d257c0832aabf1110b704cbd4d