### PR TITLE
Add service and portfolio pages

### DIFF
--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import Hero from "@/components/sections/Hero";
+import PortfolioGallery from "./portfolio-gallery";
+
+export const metadata: Metadata = {
+  title: "Portfolio | Elevate Digital",
+  description: "Explore our latest projects and case studies.",
+};
+
+export default function PortfolioPage() {
+  return (
+    <main>
+      <Hero title="Our Portfolio" />
+      <PortfolioGallery />
+    </main>
+  );
+}

--- a/src/app/portfolio/portfolio-gallery.tsx
+++ b/src/app/portfolio/portfolio-gallery.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { useState } from "react";
+import Container from "@/components/ui/Container";
+import ProjectCard from "@/components/portfolio/ProjectCard";
+import ProjectFilter from "@/components/portfolio/ProjectFilter";
+import CaseStudyPreview from "@/components/portfolio/CaseStudyPreview";
+import Button from "@/components/ui/Button";
+
+const projects = [
+  {
+    title: "E-Commerce Platform",
+    description: "Scalable storefront built with modern frameworks.",
+    image: "https://placehold.co/600x400",
+    category: "Web Development",
+  },
+  {
+    title: "Social App",
+    description: "Connect users worldwide with real-time chat.",
+    image: "https://placehold.co/600x400",
+    category: "Mobile Apps",
+  },
+  {
+    title: "SEO Campaign",
+    description: "Boosted organic traffic for a growing brand.",
+    image: "https://placehold.co/600x400",
+    category: "Digital Marketing",
+  },
+  {
+    title: "Cloud Migration",
+    description: "Moved legacy systems to a modern cloud stack.",
+    image: "https://placehold.co/600x400",
+    category: "Cloud Solutions",
+  },
+];
+
+const caseStudies = [
+  {
+    title: "Retailer Redesign",
+    result: "Sales increased 50% after launch",
+    imageBefore: "https://placehold.co/300x200?text=Before",
+    imageAfter: "https://placehold.co/300x200?text=After",
+  },
+  {
+    title: "App Performance",
+    result: "Reduced load times by 70%",
+    imageBefore: "https://placehold.co/300x200?text=Old",
+    imageAfter: "https://placehold.co/300x200?text=New",
+  },
+];
+
+export default function PortfolioGallery() {
+  const categories = ["All", "Web Development", "Mobile Apps", "Digital Marketing", "Cloud Solutions"];
+  const [filter, setFilter] = useState<string>("All");
+  const filtered = projects.filter((p) => filter === "All" || p.category === filter);
+
+  return (
+    <>
+      <section className="py-16">
+        <Container>
+          <ProjectFilter categories={categories} active={filter} onChange={setFilter} />
+          <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+            {filtered.map((p) => (
+              <ProjectCard key={p.title} {...p} />
+            ))}
+          </div>
+        </Container>
+      </section>
+      <section className="bg-gray-50 py-16 dark:bg-gray-950">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">Case Studies</h2>
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            {caseStudies.map((cs) => (
+              <CaseStudyPreview key={cs.title} {...cs} />
+            ))}
+          </div>
+          <div className="mt-12 text-center">
+            <Button variant="primary">Discuss Your Project</Button>
+          </div>
+        </Container>
+      </section>
+    </>
+  );
+}

--- a/src/app/services/cloud-solutions/page.tsx
+++ b/src/app/services/cloud-solutions/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import Container from "@/components/ui/Container";
+import Hero from "@/components/sections/Hero";
+import Button from "@/components/ui/Button";
+
+export const metadata: Metadata = {
+  title: "Cloud Solutions | Elevate Digital",
+  description: "Scalable infrastructure and DevOps services.",
+};
+
+export default function CloudSolutionsPage() {
+  const benefits = [
+    "Infrastructure as Code",
+    "CI/CD automation",
+    "Scalable hosting on major clouds",
+    "24/7 monitoring & support",
+  ];
+
+  return (
+    <main>
+      <Hero title="Cloud Solutions" subtitle="Scale With Confidence" />
+      <section className="py-16">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">What We Offer</h2>
+          <ul className="mx-auto mt-8 grid max-w-2xl gap-4 sm:grid-cols-2">
+            {benefits.map((b) => (
+              <li
+                key={b}
+                className="rounded-lg border border-gray-200 bg-white p-4 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900"
+              >
+                {b}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 text-center">
+            <Button variant="primary">Start Your Project</Button>
+          </div>
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/src/app/services/digital-marketing/page.tsx
+++ b/src/app/services/digital-marketing/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import Container from "@/components/ui/Container";
+import Hero from "@/components/sections/Hero";
+import Button from "@/components/ui/Button";
+
+export const metadata: Metadata = {
+  title: "Digital Marketing | Elevate Digital",
+  description: "Campaigns that amplify your brand online.",
+};
+
+export default function DigitalMarketingPage() {
+  const benefits = [
+    "Search engine optimization",
+    "Pay-per-click advertising",
+    "Content & social strategy",
+    "Analytics and conversion tracking",
+  ];
+
+  return (
+    <main>
+      <Hero title="Digital Marketing" subtitle="Grow Your Audience" />
+      <section className="py-16">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">What We Offer</h2>
+          <ul className="mx-auto mt-8 grid max-w-2xl gap-4 sm:grid-cols-2">
+            {benefits.map((b) => (
+              <li
+                key={b}
+                className="rounded-lg border border-gray-200 bg-white p-4 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900"
+              >
+                {b}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 text-center">
+            <Button variant="primary">Start Your Campaign</Button>
+          </div>
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/src/app/services/mobile-apps/page.tsx
+++ b/src/app/services/mobile-apps/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import Container from "@/components/ui/Container";
+import Hero from "@/components/sections/Hero";
+import Button from "@/components/ui/Button";
+
+export const metadata: Metadata = {
+  title: "Mobile Apps | Elevate Digital",
+  description: "Native and cross-platform mobile solutions.",
+};
+
+export default function MobileAppsPage() {
+  const benefits = [
+    "iOS and Android development",
+    "Cross-platform frameworks",
+    "Intuitive mobile UI/UX",
+    "App Store deployment",
+  ];
+
+  return (
+    <main>
+      <Hero title="Mobile Apps" subtitle="Reach Users Everywhere" />
+      <section className="py-16">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">What We Offer</h2>
+          <ul className="mx-auto mt-8 grid max-w-2xl gap-4 sm:grid-cols-2">
+            {benefits.map((b) => (
+              <li
+                key={b}
+                className="rounded-lg border border-gray-200 bg-white p-4 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900"
+              >
+                {b}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 text-center">
+            <Button variant="primary">Start Your Project</Button>
+          </div>
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,0 +1,169 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Container from "@/components/ui/Container";
+import Card from "@/components/ui/Card";
+import Hero from "@/components/sections/Hero";
+import Button from "@/components/ui/Button";
+
+export const metadata: Metadata = {
+  title: "Services | Elevate Digital",
+  description: "Explore our full range of digital services and pricing packages.",
+};
+
+const services = [
+  {
+    title: "Web Development",
+    href: "/services/web-development",
+    icon: (
+      <svg className="h-8 w-8" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 4a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V4z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M8 2v4M16 2v4M3 10h18" />
+      </svg>
+    ),
+    description: "Modern responsive websites built for your business.",
+  },
+  {
+    title: "Mobile Apps",
+    href: "/services/mobile-apps",
+    icon: (
+      <svg className="h-8 w-8" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+        <rect width="12" height="20" x="6" y="2" rx="2" ry="2" />
+        <path d="M12 18h.01" />
+      </svg>
+    ),
+    description: "iOS and Android applications users love.",
+  },
+  {
+    title: "Digital Marketing",
+    href: "/services/digital-marketing",
+    icon: (
+      <svg className="h-8 w-8" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 12l18-9v18L3 12z" />
+      </svg>
+    ),
+    description: "Strategies that grow your audience and brand.",
+  },
+  {
+    title: "Cloud Solutions",
+    href: "/services/cloud-solutions",
+    icon: (
+      <svg className="h-8 w-8" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 15a4 4 0 0 1 4-4 5 5 0 0 1 9.9-1A3.5 3.5 0 0 1 21 13.5 3.5 3.5 0 0 1 17.5 17H5a2 2 0 0 1-2-2z" />
+      </svg>
+    ),
+    description: "Infrastructure and DevOps for scale and reliability.",
+  },
+];
+
+const workflow = [
+  {
+    title: "Discovery",
+    description: "We collaborate to understand goals and requirements.",
+  },
+  {
+    title: "Design",
+    description: "Our team crafts user-centric wireframes and prototypes.",
+  },
+  {
+    title: "Development",
+    description: "Agile development brings your vision to life.",
+  },
+  {
+    title: "Deploy",
+    description: "Launch, monitor and iterate for ongoing success.",
+  },
+];
+
+const pricing = [
+  {
+    name: "Starter",
+    price: "$1,999",
+    features: ["Single landing page", "Basic analytics", "Email support"],
+  },
+  {
+    name: "Growth",
+    price: "$4,999",
+    features: ["Multi-page site or app", "SEO optimization", "Priority support"],
+  },
+  {
+    name: "Enterprise",
+    price: "Custom",
+    features: [
+      "Complex integrations",
+      "Dedicated project team",
+      "SLA & ongoing maintenance",
+    ],
+  },
+];
+
+export default function ServicesPage() {
+  return (
+    <main>
+      <Hero title="Our Services" />
+
+      <section className="py-16">
+        <Container>
+          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-4">
+            {services.map((service) => (
+              <Card key={service.title} className="text-center">
+                <div className="mx-auto mb-3 h-12 w-12 text-blue-600 dark:text-blue-400">
+                  {service.icon}
+                </div>
+                <h3 className="text-lg font-semibold">{service.title}</h3>
+                <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                  {service.description}
+                </p>
+                <Link href={service.href} className="mt-3 inline-block text-sm text-blue-600 hover:underline">
+                  Learn More
+                </Link>
+              </Card>
+            ))}
+          </div>
+        </Container>
+      </section>
+
+      <section className="bg-gray-50 py-16 dark:bg-gray-950">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">Our Process</h2>
+          <ol className="mx-auto mt-8 grid max-w-3xl gap-8 sm:grid-cols-2 md:grid-cols-4">
+            {workflow.map((step, idx) => (
+              <li key={step.title} className="text-center">
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white">
+                  {idx + 1}
+                </div>
+                <h3 className="mt-4 text-lg font-semibold">{step.title}</h3>
+                <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                  {step.description}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </Container>
+      </section>
+
+      <section className="py-16">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">Pricing</h2>
+          <div className="mt-8 grid gap-6 md:grid-cols-3">
+            {pricing.map((tier) => (
+              <Card key={tier.name} className="text-center">
+                <h3 className="text-lg font-semibold">{tier.name}</h3>
+                <p className="mt-1 text-2xl font-bold text-blue-600 dark:text-blue-400">
+                  {tier.price}
+                </p>
+                <ul className="mt-4 space-y-2 text-sm text-gray-600 dark:text-gray-300">
+                  {tier.features.map((f) => (
+                    <li key={f}>{f}</li>
+                  ))}
+                </ul>
+                <Button variant="primary" className="mt-6">
+                  Get Started
+                </Button>
+              </Card>
+            ))}
+          </div>
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/src/app/services/web-development/page.tsx
+++ b/src/app/services/web-development/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import Container from "@/components/ui/Container";
+import Hero from "@/components/sections/Hero";
+import Button from "@/components/ui/Button";
+
+export const metadata: Metadata = {
+  title: "Web Development | Elevate Digital",
+  description: "Custom websites that drive results.",
+};
+
+export default function WebDevelopmentPage() {
+  const benefits = [
+    "Custom responsive design",
+    "SEO-friendly architecture",
+    "Performance optimization",
+    "E-commerce integration",
+  ];
+
+  return (
+    <main>
+      <Hero title="Web Development" subtitle="Build Your Online Presence" />
+      <section className="py-16">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">What We Offer</h2>
+          <ul className="mx-auto mt-8 grid max-w-2xl gap-4 sm:grid-cols-2">
+            {benefits.map((b) => (
+              <li
+                key={b}
+                className="rounded-lg border border-gray-200 bg-white p-4 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900"
+              >
+                {b}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 text-center">
+            <Button variant="primary">Start Your Project</Button>
+          </div>
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/src/components/portfolio/CaseStudyPreview.tsx
+++ b/src/components/portfolio/CaseStudyPreview.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useState } from "react";
+import Image from "next/image";
+
+export interface CaseStudyPreviewProps {
+  title: string;
+  result: string;
+  imageBefore: string;
+  imageAfter: string;
+  className?: string;
+}
+
+export default function CaseStudyPreview({
+  title,
+  result,
+  imageBefore,
+  imageAfter,
+  className,
+}: CaseStudyPreviewProps) {
+  const [hover, setHover] = useState(false);
+
+  return (
+    <div
+      className={`overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900 ${className ?? ""}`}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <div className="relative h-40 w-full">
+        <Image
+          src={imageBefore}
+          alt={`${title} before`}
+          fill
+          className={`object-cover transition-opacity ${hover ? "opacity-0" : "opacity-100"}`}
+        />
+        <Image
+          src={imageAfter}
+          alt={`${title} after`}
+          fill
+          className={`object-cover transition-opacity ${hover ? "opacity-100" : "opacity-0"}`}
+        />
+      </div>
+      <div className="p-4">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">{result}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/portfolio/ProjectCard.tsx
+++ b/src/components/portfolio/ProjectCard.tsx
@@ -1,0 +1,46 @@
+import Image from "next/image";
+import type { ReactNode } from "react";
+
+export interface ProjectCardProps {
+  title: string;
+  description: string;
+  image: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+function cn(...classes: Array<string | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export default function ProjectCard({
+  title,
+  description,
+  image,
+  className,
+  children,
+}: ProjectCardProps) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-transform hover:scale-[1.02] dark:border-gray-800 dark:bg-gray-900",
+        className
+      )}
+    >
+      <Image
+        src={image}
+        alt={title}
+        width={600}
+        height={400}
+        className="h-40 w-full object-cover"
+      />
+      <div className="p-4">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          {description}
+        </p>
+        {children && <div className="mt-3">{children}</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/portfolio/ProjectFilter.tsx
+++ b/src/components/portfolio/ProjectFilter.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+export interface ProjectFilterProps {
+  categories: string[];
+  active: string;
+  onChange: (category: string) => void;
+  className?: string;
+}
+
+export default function ProjectFilter({
+  categories,
+  active,
+  onChange,
+  className,
+}: ProjectFilterProps) {
+  return (
+    <div className={className}>
+      <ul className="flex flex-wrap justify-center gap-2">
+        {categories.map((cat) => (
+          <li key={cat}>
+            <button
+              onClick={() => onChange(cat)}
+              className={`rounded-full px-4 py-2 text-sm transition-colors ${active === cat ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"}`}
+            >
+              {cat}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add full services page with workflow and pricing
- create individual service pages
- add portfolio gallery with project filtering and case studies
- implement new portfolio components

## Testing
- `npx next lint`
- `npx next build`


------
https://chatgpt.com/codex/tasks/task_e_6862cb69db74832a9b1bf368c753625e