### PR TITLE
Add contact forms and API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.3.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -6159,6 +6160,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.4"
+    "next": "15.3.4",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/actions/contact.ts
+++ b/src/actions/contact.ts
@@ -1,0 +1,30 @@
+'use server'
+
+import { contactSchema, newsletterSchema, quoteSchema, ContactData, NewsletterData, QuoteData, handleContact, handleNewsletter, handleQuote } from '@/lib/contact';
+
+export async function sendContact(data: ContactData) {
+  const parsed = contactSchema.safeParse(data);
+  if (!parsed.success) {
+    return { success: false, error: 'Invalid input' };
+  }
+  await handleContact(parsed.data);
+  return { success: true };
+}
+
+export async function subscribeNewsletter(data: NewsletterData) {
+  const parsed = newsletterSchema.safeParse(data);
+  if (!parsed.success) {
+    return { success: false, error: 'Invalid email' };
+  }
+  await handleNewsletter(parsed.data);
+  return { success: true };
+}
+
+export async function requestQuote(data: QuoteData) {
+  const parsed = quoteSchema.safeParse(data);
+  if (!parsed.success) {
+    return { success: false, error: 'Invalid input' };
+  }
+  await handleQuote(parsed.data);
+  return { success: true };
+}

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { contactSchema, handleContact } from '@/lib/contact';
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json();
+    const data = contactSchema.parse(json);
+    await handleContact(data);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ success: false, error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from 'next';
+import Container from '@/components/ui/Container';
+import Hero from '@/components/sections/Hero';
+import ContactForm from '@/components/forms/ContactForm';
+import QuoteRequestForm from '@/components/forms/QuoteRequestForm';
+
+export const metadata: Metadata = {
+  title: 'Contact Us | Elevate Digital',
+  description: 'Get in touch with the Elevate Digital team.',
+};
+
+export default function ContactPage() {
+  const offices = [
+    {
+      city: 'New York',
+      address: '123 Main St, New York, NY',
+      phone: '+1 (555) 123-4567',
+      map: 'https://www.openstreetmap.org/export/embed.html?bbox=-74.012%2C40.703%2C-73.99%2C40.71&layer=mapnik',
+    },
+    {
+      city: 'London',
+      address: '45 Kingsway, London',
+      phone: '+44 20 1234 5678',
+      map: 'https://www.openstreetmap.org/export/embed.html?bbox=-0.12%2C51.506%2C-0.11%2C51.513&layer=mapnik',
+    },
+  ];
+
+  const faqs = [
+    {
+      q: 'How do I request a quote?',
+      a: 'Fill out the form and we will respond within 1-2 business days.',
+    },
+    { q: 'Do you work internationally?', a: 'Yes, we work with clients around the globe.' },
+    {
+      q: 'What services do you provide?',
+      a: 'We offer web development, mobile apps, marketing and cloud solutions.',
+    },
+  ];
+
+  return (
+    <main>
+      <Hero title="Contact Elevate Digital" subtitle="We would love to hear from you" />
+
+      <section className="py-16" id="contact-form">
+        <Container>
+          <div className="grid gap-8 md:grid-cols-2">
+            <ContactForm />
+            <div>
+              <h3 className="text-lg font-semibold">Our Offices</h3>
+              <ul className="mt-4 space-y-4 text-sm text-gray-600 dark:text-gray-300">
+                {offices.map((office) => (
+                  <li key={office.city} className="rounded-md border p-4 dark:border-gray-700">
+                    <p className="font-medium">{office.city}</p>
+                    <p>{office.address}</p>
+                    <p>{office.phone}</p>
+                    <iframe
+                      title={`${office.city} map`}
+                      src={office.map}
+                      className="mt-2 h-40 w-full border"
+                      loading="lazy"
+                    />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="py-16" id="quote-request">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">Request a Quote</h2>
+          <div className="mx-auto mt-8 max-w-lg">
+            <QuoteRequestForm />
+          </div>
+        </Container>
+      </section>
+
+      <section className="py-16 bg-gray-50 dark:bg-gray-950" id="faq">
+        <Container>
+          <h2 className="text-center text-3xl font-bold">FAQ</h2>
+          <div className="mx-auto mt-8 max-w-2xl space-y-4">
+            {faqs.map((f) => (
+              <details key={f.q} className="rounded-md border p-4 dark:border-gray-700">
+                <summary className="cursor-pointer font-medium">{f.q}</summary>
+                <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">{f.a}</p>
+              </details>
+            ))}
+          </div>
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -1,0 +1,97 @@
+'use client';
+import { FormEvent, useState, useTransition } from 'react';
+import { sendContact } from '@/actions/contact';
+import Button from '@/components/ui/Button';
+import Toast from '@/components/ui/Toast';
+
+export default function ContactForm() {
+  const [pending, startTransition] = useTransition();
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const name = formData.get('name') as string;
+    const email = formData.get('email') as string;
+    const service = formData.get('service') as string;
+    const message = formData.get('message') as string;
+
+    if (!name || !email || !service || !message) {
+      setToast({ message: 'All fields are required.', type: 'error' });
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await sendContact({ name, email, service, message });
+      if (result.success) {
+        form.reset();
+        setToast({ message: 'Message sent!', type: 'success' });
+      } else {
+        setToast({ message: result.error ?? 'Something went wrong.', type: 'error' });
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4" aria-label="Contact form">
+      <div>
+        <label htmlFor="name" className="block text-sm font-medium">
+          Name
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+        />
+      </div>
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium">
+          Email
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+        />
+      </div>
+      <div>
+        <label htmlFor="service" className="block text-sm font-medium">
+          Service Interest
+        </label>
+        <select
+          id="service"
+          name="service"
+          required
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+        >
+          <option value="">Select a service</option>
+          <option value="web">Web Development</option>
+          <option value="mobile">Mobile Apps</option>
+          <option value="marketing">Digital Marketing</option>
+          <option value="cloud">Cloud Solutions</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="message" className="block text-sm font-medium">
+          Message
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          required
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+          rows={4}
+        />
+      </div>
+      <Button type="submit" disabled={pending} className="w-full">
+        {pending ? 'Sending...' : 'Send Message'}
+      </Button>
+      {toast && <Toast {...toast} onClose={() => setToast(null)} />}
+    </form>
+  );
+}

--- a/src/components/forms/NewsletterForm.tsx
+++ b/src/components/forms/NewsletterForm.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { FormEvent, useState, useTransition } from 'react';
+import { subscribeNewsletter } from '@/actions/contact';
+import Button from '@/components/ui/Button';
+import Toast from '@/components/ui/Toast';
+
+export default function NewsletterForm() {
+  const [pending, startTransition] = useTransition();
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const email = (formData.get('email') as string) || '';
+    if (!email) {
+      setToast({ message: 'Email is required.', type: 'error' });
+      return;
+    }
+    startTransition(async () => {
+      const result = await subscribeNewsletter({ email });
+      if (result.success) {
+        form.reset();
+        setToast({ message: 'Subscribed!', type: 'success' });
+      } else {
+        setToast({ message: result.error ?? 'Invalid email.', type: 'error' });
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex max-w-xs" aria-label="Newsletter subscription">
+      <label htmlFor="newsletter" className="sr-only">
+        Email
+      </label>
+      <input
+        id="newsletter"
+        name="email"
+        type="email"
+        required
+        className="w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+        placeholder="Email address"
+      />
+      <Button type="submit" disabled={pending} className="rounded-l-none" variant="primary">
+        {pending ? 'Sending...' : 'Subscribe'}
+      </Button>
+      {toast && <Toast {...toast} onClose={() => setToast(null)} />}
+    </form>
+  );
+}

--- a/src/components/forms/QuoteRequestForm.tsx
+++ b/src/components/forms/QuoteRequestForm.tsx
@@ -1,0 +1,95 @@
+'use client';
+import { FormEvent, useState, useTransition } from 'react';
+import { requestQuote } from '@/actions/contact';
+import Button from '@/components/ui/Button';
+import Toast from '@/components/ui/Toast';
+
+export default function QuoteRequestForm() {
+  const [pending, startTransition] = useTransition();
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const name = formData.get('name') as string;
+    const email = formData.get('email') as string;
+    const service = formData.get('service') as string;
+    const message = formData.get('message') as string;
+    if (!name || !email || !service || !message) {
+      setToast({ message: 'All fields are required.', type: 'error' });
+      return;
+    }
+    startTransition(async () => {
+      const result = await requestQuote({ name, email, service, message });
+      if (result.success) {
+        form.reset();
+        setToast({ message: 'Request sent!', type: 'success' });
+      } else {
+        setToast({ message: result.error ?? 'Something went wrong.', type: 'error' });
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4" aria-label="Quote request form">
+      <div>
+        <label htmlFor="qname" className="block text-sm font-medium">
+          Name
+        </label>
+        <input
+          id="qname"
+          name="name"
+          type="text"
+          required
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+        />
+      </div>
+      <div>
+        <label htmlFor="qemail" className="block text-sm font-medium">
+          Email
+        </label>
+        <input
+          id="qemail"
+          name="email"
+          type="email"
+          required
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+        />
+      </div>
+      <div>
+        <label htmlFor="qservice" className="block text-sm font-medium">
+          Service Interest
+        </label>
+        <select
+          id="qservice"
+          name="service"
+          required
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+        >
+          <option value="">Select a service</option>
+          <option value="web">Web Development</option>
+          <option value="mobile">Mobile Apps</option>
+          <option value="marketing">Digital Marketing</option>
+          <option value="cloud">Cloud Solutions</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="qmessage" className="block text-sm font-medium">
+          Message
+        </label>
+        <textarea
+          id="qmessage"
+          name="message"
+          required
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+          rows={4}
+        />
+      </div>
+      <Button type="submit" disabled={pending} className="w-full">
+        {pending ? 'Sending...' : 'Request Quote'}
+      </Button>
+      {toast && <Toast {...toast} onClose={() => setToast(null)} />}
+    </form>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import Navigation, { NavItem } from "./Navigation";
-import Button from "@/components/ui/Button";
+import NewsletterForm from "@/components/forms/NewsletterForm";
 
 export interface FooterProps {
   className?: string;
@@ -44,21 +44,9 @@ export default function Footer({ className }: FooterProps) {
         <div>
           <h4 className="text-sm font-semibold">Contact Us</h4>
           <p className="mt-2 text-sm">info@elevatedigital.com</p>
-          <form className="mt-4 flex max-w-xs">
-            <label htmlFor="newsletter" className="sr-only">
-              Email
-            </label>
-            <input
-              id="newsletter"
-              type="email"
-              required
-              className="w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
-              placeholder="Email address"
-            />
-            <Button type="submit" className="rounded-l-none" variant="primary">
-              Subscribe
-            </Button>
-          </form>
+          <div className="mt-4">
+            <NewsletterForm />
+          </div>
         </div>
       </div>
       <div className="mt-12 border-t border-gray-200 pt-4 text-center text-xs dark:border-gray-700">

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect } from 'react';
+
+export interface ToastProps {
+  message: string;
+  type: 'success' | 'error';
+  onClose?: () => void;
+}
+
+export default function Toast({ message, type, onClose }: ToastProps) {
+  useEffect(() => {
+    const id = setTimeout(() => onClose?.(), 4000);
+    return () => clearTimeout(id);
+  }, [onClose]);
+
+  return (
+    <div
+      role="alert"
+      className={`fixed bottom-4 right-4 rounded-md px-4 py-2 text-sm text-white ${
+        type === 'success' ? 'bg-green-600' : 'bg-red-600'
+      }`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const contactSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  service: z.string().min(1),
+  message: z.string().min(1),
+});
+
+export const newsletterSchema = z.object({
+  email: z.string().email(),
+});
+
+export const quoteSchema = contactSchema;
+
+export type ContactData = z.infer<typeof contactSchema>;
+export type NewsletterData = z.infer<typeof newsletterSchema>;
+export type QuoteData = z.infer<typeof quoteSchema>;
+
+async function sendEmail(subject: string, body: string) {
+  console.log('Mock email:', { subject, body });
+}
+
+export async function handleContact(data: ContactData) {
+  await sendEmail(`Contact from ${data.name}`, `${data.message}\nService: ${data.service}\nEmail: ${data.email}`);
+}
+
+export async function handleNewsletter(data: NewsletterData) {
+  await sendEmail('Newsletter subscription', data.email);
+}
+
+export async function handleQuote(data: QuoteData) {
+  await sendEmail(`Quote request from ${data.name}`, `${data.message}\nService: ${data.service}\nEmail: ${data.email}`);
+}


### PR DESCRIPTION
## Summary
- add contact page with office details, quote form, and FAQ
- build forms for contact, newsletter, and quotes
- add toast notifications
- create contact API route and server actions
- mock server-side email logic
- integrate newsletter subscription in the footer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862ce72f59c832ab784bec0c9e709c2