### PR TITLE
Add animations and polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "elevate-digital",
       "version": "0.1.0",
       "dependencies": {
+        "framer-motion": "^12.20.1",
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3334,6 +3335,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.20.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.20.1.tgz",
+      "integrity": "sha512-NW2t2GHQcNvLHq18JyNVY15VKrwru+nkNyhLdqf4MbxbGhxZcSDi68iNcAy6O1nG0yYAQJbLioBIH1Kmg8Xr1g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.20.1",
+        "motion-utils": "^12.19.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4605,6 +4633,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.20.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.20.1.tgz",
+      "integrity": "sha512-XyveLJ9dmQTmaEsP9RlcuoNFxWlRIGdasdPJBB4aOwPr8bRcJdhltudAbiEjRQBmsGD30sjJdaEjhkHsAHapLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -9,20 +9,21 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "framer-motion": "^12.20.1",
+    "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.4",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://example.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+  <url>
+    <loc>https://example.com/about</loc>
+  </url>
+  <url>
+    <loc>https://example.com/services</loc>
+  </url>
+  <url>
+    <loc>https://example.com/contact</loc>
+  </url>
+  <url>
+    <loc>https://example.com/portfolio</loc>
+  </url>
+</urlset>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
+import PageTransition from "@/components/ui/PageTransition";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -18,6 +19,21 @@ export const metadata: Metadata = {
   title: "Elevate Digital | Transforming Ideas Into Digital Excellence",
   description:
     "Elevate Digital crafts web, mobile, marketing and cloud solutions to help businesses thrive.",
+  openGraph: {
+    title: 'Elevate Digital',
+    description:
+      'Elevate Digital crafts web, mobile, marketing and cloud solutions to help businesses thrive.',
+    url: 'https://example.com',
+    siteName: 'Elevate Digital',
+    images: [{ url: '/favicon.ico', width: 48, height: 48 }],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Elevate Digital',
+    description:
+      'Elevate Digital crafts web, mobile, marketing and cloud solutions to help businesses thrive.',
+  },
 };
 
 export default function RootLayout({
@@ -31,7 +47,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Header />
-        {children}
+        <PageTransition>{children}</PageTransition>
         <Footer />
       </body>
     </html>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center text-center">
+      <h1 className="text-5xl font-bold">404</h1>
+      <p className="mt-4 text-lg">Page not found.</p>
+      <Link href="/" className="mt-6 text-blue-600 underline">
+        Go back home
+      </Link>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
 import Container from "@/components/ui/Container";
+import AnimatedSection from "@/components/ui/AnimatedSection";
 
 export default function Home() {
   const services = [
@@ -15,15 +16,23 @@ export default function Home() {
       <section id="home" className="relative flex min-h-screen items-center justify-center text-center text-white">
         <div className="absolute inset-0 bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 animate-gradient" />
         <Container className="relative z-10 py-32">
-          <h1 className="text-4xl font-bold sm:text-6xl">Elevate Digital</h1>
-          <p className="mt-4 text-xl sm:text-2xl">Transforming Ideas Into Digital Excellence</p>
-          <p className="mx-auto mt-6 max-w-2xl text-base sm:text-lg">
-            We craft cutting-edge digital solutions that help your business thrive in a connected world.
-          </p>
-          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <Button variant="primary">Get Started</Button>
-            <Button variant="outline">View Our Work</Button>
-          </div>
+          <AnimatedSection>
+            <h1 className="text-4xl font-bold sm:text-6xl">Elevate Digital</h1>
+          </AnimatedSection>
+          <AnimatedSection delay={0.1}>
+            <p className="mt-4 text-xl sm:text-2xl">Transforming Ideas Into Digital Excellence</p>
+          </AnimatedSection>
+          <AnimatedSection delay={0.2}>
+            <p className="mx-auto mt-6 max-w-2xl text-base sm:text-lg">
+              We craft cutting-edge digital solutions that help your business thrive in a connected world.
+            </p>
+          </AnimatedSection>
+          <AnimatedSection delay={0.3}>
+            <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+              <Button variant="primary">Get Started</Button>
+              <Button variant="outline">View Our Work</Button>
+            </div>
+          </AnimatedSection>
         </Container>
       </section>
 
@@ -40,10 +49,12 @@ export default function Home() {
         <Container>
           <h2 className="text-center text-3xl font-bold">Our Services</h2>
           <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-4">
-            {services.map((service) => (
-              <Card key={service.title} title={service.title}>
-                <p className="text-sm text-gray-600 dark:text-gray-300">{service.description}</p>
-              </Card>
+            {services.map((service, i) => (
+              <AnimatedSection key={service.title} delay={i * 0.1}>
+                <Card title={service.title}>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">{service.description}</p>
+                </Card>
+              </AnimatedSection>
             ))}
           </div>
         </Container>

--- a/src/app/portfolio/portfolio-gallery.tsx
+++ b/src/app/portfolio/portfolio-gallery.tsx
@@ -5,6 +5,7 @@ import ProjectCard from "@/components/portfolio/ProjectCard";
 import ProjectFilter from "@/components/portfolio/ProjectFilter";
 import CaseStudyPreview from "@/components/portfolio/CaseStudyPreview";
 import Button from "@/components/ui/Button";
+import AnimatedSection from "@/components/ui/AnimatedSection";
 
 const projects = [
   {
@@ -59,8 +60,10 @@ export default function PortfolioGallery() {
         <Container>
           <ProjectFilter categories={categories} active={filter} onChange={setFilter} />
           <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
-            {filtered.map((p) => (
-              <ProjectCard key={p.title} {...p} />
+            {filtered.map((p, i) => (
+              <AnimatedSection key={p.title} delay={i * 0.1}>
+                <ProjectCard {...p} />
+              </AnimatedSection>
             ))}
           </div>
         </Container>
@@ -69,8 +72,10 @@ export default function PortfolioGallery() {
         <Container>
           <h2 className="text-center text-3xl font-bold">Case Studies</h2>
           <div className="mt-8 grid gap-6 md:grid-cols-2">
-            {caseStudies.map((cs) => (
-              <CaseStudyPreview key={cs.title} {...cs} />
+            {caseStudies.map((cs, i) => (
+              <AnimatedSection key={cs.title} delay={i * 0.1}>
+                <CaseStudyPreview {...cs} />
+              </AnimatedSection>
             ))}
           </div>
           <div className="mt-12 text-center">

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -3,6 +3,7 @@ import { FormEvent, useState, useTransition } from 'react';
 import { sendContact } from '@/actions/contact';
 import Button from '@/components/ui/Button';
 import Toast from '@/components/ui/Toast';
+import Spinner from '@/components/ui/Spinner';
 
 export default function ContactForm() {
   const [pending, startTransition] = useTransition();
@@ -88,7 +89,8 @@ export default function ContactForm() {
           rows={4}
         />
       </div>
-      <Button type="submit" disabled={pending} className="w-full">
+      <Button type="submit" disabled={pending} className="w-full gap-2">
+        {pending && <Spinner />}
         {pending ? 'Sending...' : 'Send Message'}
       </Button>
       {toast && <Toast {...toast} onClose={() => setToast(null)} />}

--- a/src/components/forms/QuoteRequestForm.tsx
+++ b/src/components/forms/QuoteRequestForm.tsx
@@ -3,6 +3,7 @@ import { FormEvent, useState, useTransition } from 'react';
 import { requestQuote } from '@/actions/contact';
 import Button from '@/components/ui/Button';
 import Toast from '@/components/ui/Toast';
+import Spinner from '@/components/ui/Spinner';
 
 export default function QuoteRequestForm() {
   const [pending, startTransition] = useTransition();
@@ -86,7 +87,8 @@ export default function QuoteRequestForm() {
           rows={4}
         />
       </div>
-      <Button type="submit" disabled={pending} className="w-full">
+      <Button type="submit" disabled={pending} className="w-full gap-2">
+        {pending && <Spinner />}
         {pending ? 'Sending...' : 'Request Quote'}
       </Button>
       {toast && <Toast {...toast} onClose={() => setToast(null)} />}

--- a/src/components/portfolio/CaseStudyPreview.tsx
+++ b/src/components/portfolio/CaseStudyPreview.tsx
@@ -31,12 +31,14 @@ export default function CaseStudyPreview({
           alt={`${title} before`}
           fill
           className={`object-cover transition-opacity ${hover ? "opacity-0" : "opacity-100"}`}
+          loading="lazy"
         />
         <Image
           src={imageAfter}
           alt={`${title} after`}
           fill
           className={`object-cover transition-opacity ${hover ? "opacity-100" : "opacity-0"}`}
+          loading="lazy"
         />
       </div>
       <div className="p-4">

--- a/src/components/portfolio/ProjectCard.tsx
+++ b/src/components/portfolio/ProjectCard.tsx
@@ -33,6 +33,7 @@ export default function ProjectCard({
         width={600}
         height={400}
         className="h-40 w-full object-cover"
+        loading="lazy"
       />
       <div className="p-4">
         <h3 className="text-lg font-semibold">{title}</h3>

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
+import AnimatedSection from "@/components/ui/AnimatedSection";
 
 export interface Stat {
   label: string;
@@ -54,19 +55,21 @@ export default function Stats({ stats, className }: StatsProps) {
   }, [inView]);
 
   return (
-    <div ref={ref} className={className}>
-      <dl className="grid grid-cols-2 gap-8 md:grid-cols-4">
-        {stats.map((stat, i) => (
-          <div key={stat.label} className="text-center">
-            <dt className="text-3xl font-bold text-blue-600 dark:text-blue-400">
-              {counts[i]}
-            </dt>
-            <dd className="mt-1 text-sm font-medium text-gray-600 dark:text-gray-300">
-              {stat.label}
-            </dd>
-          </div>
-        ))}
-      </dl>
-    </div>
+    <AnimatedSection className={className}>
+      <div ref={ref}>
+        <dl className="grid grid-cols-2 gap-8 md:grid-cols-4">
+          {stats.map((stat, i) => (
+            <div key={stat.label} className="text-center">
+              <dt className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+                {counts[i]}
+              </dt>
+              <dd className="mt-1 text-sm font-medium text-gray-600 dark:text-gray-300">
+                {stat.label}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </AnimatedSection>
   );
 }

--- a/src/components/sections/Team.tsx
+++ b/src/components/sections/Team.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
+import AnimatedSection from "@/components/ui/AnimatedSection";
 
 export interface SocialLinks {
   twitter?: string;
@@ -39,36 +40,29 @@ function useInView<T extends HTMLElement>(options?: IntersectionObserverInit) {
 }
 
 export default function Team({ members, className }: TeamProps) {
-  const { ref, inView } = useInView<HTMLDivElement>({ threshold: 0.2 });
+  const { ref } = useInView<HTMLDivElement>({ threshold: 0.2 });
 
   return (
     <div
       ref={ref}
-      className={
-        "grid gap-8 sm:grid-cols-2 md:grid-cols-3 " + (className ?? "")
-      }
+      className={"grid gap-8 sm:grid-cols-2 md:grid-cols-3 " + (className ?? "")}
     >
       {members.map((member, idx) => (
-        <div
-          key={member.name}
-          className={`rounded-lg border border-gray-200 bg-white p-6 text-center shadow-sm transition duration-700 dark:border-gray-800 dark:bg-gray-900 ${
-            inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
-          }`}
-          style={{ transitionDelay: `${idx * 100}ms` }}
-        >
-          <div className="mx-auto h-24 w-24 overflow-hidden rounded-full">
-            <Image
-              src={member.image}
-              alt={member.name}
-              width={96}
-              height={96}
-            />
-          </div>
-          <h3 className="mt-4 text-lg font-semibold">{member.name}</h3>
-          <p className="text-sm text-gray-500 dark:text-gray-400">{member.title}</p>
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">{member.bio}</p>
-          {member.social && (
-            <div className="mt-3 flex justify-center space-x-4" aria-label="Social links">
+        <AnimatedSection key={member.name} delay={idx * 0.1}>
+          <div className="rounded-lg border border-gray-200 bg-white p-6 text-center shadow-sm dark:border-gray-800 dark:bg-gray-900">
+            <div className="mx-auto h-24 w-24 overflow-hidden rounded-full">
+              <Image
+                src={member.image}
+                alt={member.name}
+                width={96}
+                height={96}
+              />
+            </div>
+            <h3 className="mt-4 text-lg font-semibold">{member.name}</h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400">{member.title}</p>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">{member.bio}</p>
+            {member.social && (
+              <div className="mt-3 flex justify-center space-x-4" aria-label="Social links">
               {member.social.twitter && (
                 <a href={member.social.twitter} className="hover:text-blue-600" aria-label="Twitter">
                   <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -92,7 +86,8 @@ export default function Team({ members, className }: TeamProps) {
               )}
             </div>
           )}
-        </div>
+          </div>
+        </AnimatedSection>
       ))}
     </div>
   );

--- a/src/components/ui/AnimatedSection.tsx
+++ b/src/components/ui/AnimatedSection.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { motion, useAnimation, useInView } from 'framer-motion';
+import { useEffect, useRef, type ReactNode } from 'react';
+
+export interface AnimatedSectionProps {
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+}
+
+export default function AnimatedSection({ children, className, delay = 0 }: AnimatedSectionProps) {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '0px 0px -100px 0px' });
+  const controls = useAnimation();
+
+  useEffect(() => {
+    if (inView) {
+      controls.start('visible');
+    }
+  }, [inView, controls]);
+
+  return (
+    <motion.section
+      ref={ref}
+      initial="hidden"
+      animate={controls}
+      variants={{
+        hidden: { opacity: 0, y: 40 },
+        visible: { opacity: 1, y: 0, transition: { duration: 0.6, delay } },
+      }}
+      className={className}
+    >
+      {children}
+    </motion.section>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,6 @@
+'use client';
 import type { ButtonHTMLAttributes } from "react";
+import { motion } from 'framer-motion';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "outline";
@@ -21,5 +23,12 @@ function cn(...classes: Array<string | undefined>) {
 }
 
 export default function Button({ variant = "primary", className, ...props }: ButtonProps) {
-  return <button className={cn(base, variants[variant], className)} {...props} />;
+  return (
+    <motion.button
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.98 }}
+      className={cn(base, variants[variant], className)}
+      {...props}
+    />
+  );
 }

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -12,7 +12,12 @@ function cn(...classes: Array<string | undefined>) {
 
 export default function Card({ title, children, className }: CardProps) {
   return (
-    <div className={cn("rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900", className)}>
+    <div
+      className={cn(
+        "rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition-transform hover:-translate-y-1 hover:shadow-lg dark:border-gray-800 dark:bg-gray-900",
+        className,
+      )}
+    >
       {title && <h3 className="mb-2 text-lg font-semibold">{title}</h3>}
       {children}
     </div>

--- a/src/components/ui/PageTransition.tsx
+++ b/src/components/ui/PageTransition.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { usePathname } from 'next/navigation';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { ReactNode } from 'react';
+
+export default function PageTransition({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { motion } from 'framer-motion';
+
+export default function Spinner({ className }: { className?: string }) {
+  return (
+    <motion.span
+      className={className}
+      animate={{ rotate: 360 }}
+      transition={{ repeat: Infinity, ease: 'linear', duration: 1 }}
+    >
+      <svg
+        className="h-5 w-5"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <circle cx="12" cy="12" r="10" className="opacity-25" />
+        <path d="M22 12a10 10 0 0 1-10 10" />
+      </svg>
+    </motion.span>
+  );
+}


### PR DESCRIPTION
## Summary
- install framer-motion
- add reusable `AnimatedSection` and `PageTransition` components
- enhance buttons, cards and forms with micro-interactions
- animate hero, services, stats, team and portfolio items
- add lazy loading for portfolio images
- include spinner component and loading states
- improve metadata for social sharing
- provide 404 page plus sitemap and robots.txt

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862d06e68ac832a87d89184c78869e1