### PR TITLE
Add custom background color prop to Card

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -4,19 +4,29 @@ interface CardProps {
   title?: string;
   children?: ReactNode;
   className?: string;
+  /**
+   * Optional custom background color. Accepts any valid CSS color value.
+   */
+  backgroundColor?: string;
 }
 
 function cn(...classes: Array<string | undefined>) {
   return classes.filter(Boolean).join(" ");
 }
 
-export default function Card({ title, children, className }: CardProps) {
+export default function Card({
+  title,
+  children,
+  className,
+  backgroundColor,
+}: CardProps) {
   return (
     <div
       className={cn(
         "rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition-transform hover:-translate-y-1 hover:shadow-lg dark:border-gray-800 dark:bg-gray-900",
         className,
       )}
+      style={backgroundColor ? { backgroundColor } : undefined}
     >
       {title && <h3 className="mb-2 text-lg font-semibold">{title}</h3>}
       {children}


### PR DESCRIPTION
## Summary
- extend `Card` props to accept `backgroundColor`
- apply optional inline style to change background color

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862e004e3b8832a8fe5f449c589857b